### PR TITLE
fix(web): ensure sidebar header tooltips appear above scrollbar

### DIFF
--- a/src/compose_farm/web/templates/base.html
+++ b/src/compose_farm/web/templates/base.html
@@ -48,7 +48,7 @@
         <div class="drawer-side">
             <label for="drawer-toggle" class="drawer-overlay" aria-label="close sidebar"></label>
             <aside id="sidebar" class="w-64 bg-base-100 border-r border-base-300 flex flex-col min-h-screen">
-                <header class="p-4 border-b border-base-300">
+                <header class="p-4 border-b border-base-300 relative z-10">
                     <h2 class="text-lg font-semibold flex items-center gap-2">
                         <span class="rainbow-hover">Compose Farm</span>
                         <div class="tooltip tooltip-bottom" data-tip="Docs">


### PR DESCRIPTION
## Summary
- Add `relative z-10` to the sidebar header so its tooltips render above the nav element's scrollbar
- Fixes the "Change theme" tooltip being hidden behind the scrollbar