### PR TITLE
fix: Explicitly disable SSH agent when using dedicated keys

### DIFF
--- a/src/compose_farm/executor.py
+++ b/src/compose_farm/executor.py
@@ -191,6 +191,7 @@ def ssh_connect_kwargs(host: Host) -> dict[str, Any]:
         # If dedicated key exists, force use of it and ignore agent
         # This avoids issues with stale/broken forwarded agents in Docker
         kwargs["client_keys"] = [str(key_path)]
+        kwargs["agent_path"] = None  # Prevent asyncssh from using SSH_AUTH_SOCK
     elif agent_path:
         # Fallback to agent if no dedicated key
         kwargs["agent_path"] = agent_path

--- a/tests/test_ssh_keys.py
+++ b/tests/test_ssh_keys.py
@@ -217,6 +217,7 @@ class TestSshConnectKwargs:
             result = ssh_connect_kwargs(host)
 
             assert result["client_keys"] == [str(key_path)]
+            assert result["agent_path"] is None
 
     def test_includes_both_agent_and_key(self, tmp_path: Path) -> None:
         """Prioritize client_keys over agent_path when both available."""
@@ -229,8 +230,8 @@ class TestSshConnectKwargs:
         ):
             result = ssh_connect_kwargs(host)
 
-            # Agent should be ignored in favor of the dedicated key
-            assert "agent_path" not in result
+            # Agent must be explicitly disabled so asyncssh doesn't use SSH_AUTH_SOCK
+            assert result["agent_path"] is None
             assert result["client_keys"] == [str(key_path)]
 
     def test_custom_port(self) -> None:


### PR DESCRIPTION
## Summary

- When dedicated compose-farm keys exist (`~/.ssh/compose-farm/id_ed25519`), explicitly set `agent_path=None` to prevent asyncssh from querying `SSH_AUTH_SOCK`
- Without this fix, a stale/broken SSH agent socket causes `ConnectionResetError` crashes even though dedicated keys are configured
- The SSH agent fallback (when no dedicated keys exist) is unchanged

## Root cause

`asyncssh.connect()` defaults to using `SSH_AUTH_SOCK` when `agent_path` is not explicitly set — even if `client_keys` are provided. The existing code set `client_keys` but left `agent_path` unset, so asyncssh would still attempt to talk to the SSH agent. If that socket was stale (e.g., forwarded agent in a Docker/NAS environment), the connection crashed with `ConnectionResetError` before the dedicated key was tried.

## Test plan

- [x] Existing `test_includes_client_keys_when_key_exists` updated to verify `agent_path is None`
- [x] Existing `test_includes_both_agent_and_key` updated to verify `agent_path is None` (was checking `"agent_path" not in result`)
- [x] All 18 SSH key tests pass