### PR TITLE
Color stack output prefixes

### DIFF
--- a/src/compose_farm/console.py
+++ b/src/compose_farm/console.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
+from hashlib import blake2b
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from rich.console import Console
+
+_STACK_PREFIX_STYLES = (
+    "cyan",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "bright_cyan",
+    "bright_green",
+    "bright_yellow",
+    "bright_blue",
+    "bright_magenta",
+)
 
 
 class _LazyConsole:
@@ -33,6 +47,19 @@ class _LazyConsole:
 
 console: Any = _LazyConsole()
 err_console: Any = _LazyConsole(stderr=True)
+
+
+def _stack_prefix_style(stack: str) -> str:
+    digest = blake2b(stack.encode("utf-8"), digest_size=1).digest()[0]
+    return _STACK_PREFIX_STYLES[digest % len(_STACK_PREFIX_STYLES)]
+
+
+def format_stack_prefix(stack: str) -> str:
+    """Format a bracketed stack prefix with a stable per-stack color."""
+    # Lazy import: Rich markup escaping is only needed when rendering stack prefixes.
+    from rich.markup import escape  # noqa: PLC0415
+
+    return f"[{_stack_prefix_style(stack)}]\\[{escape(stack)}][/]"
 
 
 # --- Message Constants ---

--- a/src/compose_farm/executor.py
+++ b/src/compose_farm/executor.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
-from .console import console, err_console
+from .console import console, err_console, format_stack_prefix
 from .ssh_keys import get_key_path, get_ssh_auth_sock, get_ssh_env
 
 if TYPE_CHECKING:
@@ -84,7 +84,7 @@ async def _stream_output_lines(
         text = line.decode() if isinstance(line, bytes) else line
         if text.strip():
             if prefix:
-                out.print(f"[cyan]\\[{prefix}][/] {escape(text)}", end="")
+                out.print(f"{format_stack_prefix(prefix)} {escape(text)}", end="")
             else:
                 out.print(escape(text), end="")
 
@@ -251,7 +251,7 @@ async def _run_local_command(
             stderr=stderr_data.decode() if stderr_data else "",
         )
     except OSError as e:
-        err_console.print(f"[cyan]\\[{stack}][/] [red]Local error:[/] {e}")
+        err_console.print(f"{format_stack_prefix(stack)} [red]Local error:[/] {e}")
         return CommandResult(stack=stack, exit_code=1, success=False)
 
 
@@ -308,7 +308,7 @@ async def _run_ssh_command(
                     stderr=stderr_data,
                 )
     except (OSError, asyncssh.Error) as e:
-        err_console.print(f"[cyan]\\[{stack}][/] [red]SSH error:[/] {e}")
+        err_console.print(f"{format_stack_prefix(stack)} [red]SSH error:[/] {e}")
         return CommandResult(stack=stack, exit_code=1, success=False)
 
 

--- a/src/compose_farm/operations.py
+++ b/src/compose_farm/operations.py
@@ -10,7 +10,14 @@ import asyncio
 from typing import TYPE_CHECKING, NamedTuple
 
 from .compose import parse_devices, parse_external_networks, parse_host_volumes
-from .console import console, err_console, print_error, print_success, print_warning
+from .console import (
+    console,
+    err_console,
+    format_stack_prefix,
+    print_error,
+    print_success,
+    print_warning,
+)
 from .executor import (
     CommandResult,
     check_networks_exist,
@@ -174,7 +181,7 @@ def _report_preflight_failures(
     preflight: PreflightResult,
 ) -> None:
     """Report pre-flight check failures."""
-    print_error(f"[cyan]\\[{stack}][/] Cannot start on [magenta]{target_host}[/]:")
+    print_error(f"{format_stack_prefix(stack)} Cannot start on [magenta]{target_host}[/]:")
     for path in preflight.missing_paths:
         print_error(f"  missing path: {path}")
     for net in preflight.missing_networks:
@@ -416,7 +423,7 @@ async def up_stacks(
             multi_results = await asyncio.gather(
                 *[
                     _up_multi_host_stack(
-                        cfg, stack, f"[cyan]\\[{stack}][/]", raw=raw, pull=pull, build=build
+                        cfg, stack, format_stack_prefix(stack), raw=raw, pull=pull, build=build
                     )
                     for stack in multi_host
                 ]
@@ -428,7 +435,7 @@ async def up_stacks(
         if needs_migration:
             total = len(needs_migration)
             for idx, stack in enumerate(needs_migration, 1):
-                prefix = f"[dim][{idx}/{total}][/] [cyan]\\[{stack}][/]"
+                prefix = f"[dim][{idx}/{total}][/] {format_stack_prefix(stack)}"
                 results.append(
                     await _up_single_stack(cfg, stack, prefix, raw=raw, pull=pull, build=build)
                 )

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,7 +1,9 @@
 """Tests for executor module."""
 
 import sys
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,6 +12,7 @@ from compose_farm.config import Config, Host
 from compose_farm.executor import (
     CommandResult,
     _run_local_command,
+    _stream_output_lines,
     check_networks_exist,
     check_paths_exist,
     check_stack_running,
@@ -23,6 +26,46 @@ from compose_farm.executor import (
 
 # These tests run actual shell commands that only work on Linux
 linux_only = pytest.mark.skipif(sys.platform != "linux", reason="Linux-only shell commands")
+
+
+async def _async_lines(lines: list[str | bytes]) -> AsyncIterator[str | bytes]:
+    for line in lines:
+        yield line
+
+
+class _RecordingConsole:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((args, kwargs))
+
+
+class TestStreamOutputLines:
+    """Tests for streaming command output formatting."""
+
+    def test_format_stack_prefix_uses_stable_distinct_colors(self) -> None:
+        from compose_farm.console import format_stack_prefix
+
+        assert format_stack_prefix("wakapi") == "[yellow]\\[wakapi][/]"
+        assert format_stack_prefix("ollama") == "[bright_green]\\[ollama][/]"
+        assert format_stack_prefix("openclaw") == "[bright_blue]\\[openclaw][/]"
+        assert format_stack_prefix("wakapi") == format_stack_prefix("wakapi")
+
+    async def test_stream_output_lines_uses_colored_prefix_and_escapes_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from compose_farm import executor
+        from compose_farm.console import format_stack_prefix
+
+        output = _RecordingConsole()
+        monkeypatch.setattr(executor, "console", output)
+
+        await _stream_output_lines(_async_lines(["Downloading [ok]\n"]), "wakapi")
+
+        assert output.calls == [
+            ((f"{format_stack_prefix('wakapi')} Downloading \\[ok]\n",), {"end": ""})
+        ]
 
 
 class TestIsLocal:


### PR DESCRIPTION
## Summary
- Add a shared formatter for bracketed stack prefixes with stable per-stack colors.
- Use it for live streamed command output plus existing bracketed operation/error prefixes.
- Add regression coverage for deterministic colors and escaped streamed output.

## Verification
- `uv run pytest tests/test_executor.py::TestStreamOutputLines -v`
- `uv run pytest tests/test_executor.py -v`
- `just lint`
- `just test`