### PR TITLE
fix: handle required vars in compose interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Start stacks (docker compose up -d). Auto-migrates if host changed.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a            Run on all stacks                                             │
@@ -583,7 +583,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Stop stacks (docker compose down).
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all       -a            Run on all stacks                                            │
@@ -619,7 +619,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Stop services without removing containers (docker compose stop).
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a            Run on all stacks                                             │
@@ -655,7 +655,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Pull latest images (docker compose pull).
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a            Run on all stacks                                             │
@@ -691,7 +691,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Restart running containers (docker compose restart).
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a            Run on all stacks                                             │
@@ -727,7 +727,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Update stacks (pull + build + up). Shorthand for 'up --pull --build'.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a            Run on all stacks                                             │
@@ -820,9 +820,9 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
    cf compose mystack config        - view parsed config
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│ *    stack        TEXT       Stack to operate on (use '.' for current dir) [required]  │
-│ *    command      TEXT       Docker compose command [required]                         │
-│      args         [ARGS]...  Additional arguments                                      │
+│ *    stack          TEXT  Stack to operate on (use '.' for current dir) [required]     │
+│ *    command        TEXT  Docker compose command [required]                            │
+│      [args]...      TEXT  Additional arguments                                         │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --host    -H      TEXT  Filter to stacks on this host                                  │
@@ -858,7 +858,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Generate a Traefik file-provider fragment from compose Traefik labels.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all     -a            Run on all stacks                                              │
@@ -903,7 +903,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Use 'cf apply' to make reality match your config (stop orphans, migrate).
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all       -a            Run on all stacks                                            │
@@ -945,7 +945,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Use --local to skip SSH-based checks for faster validation.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --local                 Skip SSH-based checks (faster)                                 │
@@ -984,7 +984,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  consistent networking.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   hosts      [HOSTS]...  Hosts to create network on (default: all)                     │
+│   [hosts]...      TEXT  Hosts to create network on (default: all)                      │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --network  -n      TEXT  Network name [default: mynetwork]                             │
@@ -1096,7 +1096,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  Show stack logs. With --service, shows logs for just that service.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a               Run on all stacks                                          │
@@ -1140,7 +1140,7 @@ Full `--help` output for each command. See the [Usage](#usage) table above for a
  With --service: filters to a specific service within the stack.
 
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────╮
-│   stacks      [STACKS]...  Stacks to operate on                                        │
+│   [stacks]...      TEXT  Stacks to operate on                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --all      -a            Run on all stacks                                             │

--- a/src/compose_farm/compose.py
+++ b/src/compose_farm/compose.py
@@ -21,7 +21,7 @@ _PUBLISHED_TARGET_PARTS = 2
 _HOST_PUBLISHED_PARTS = 3
 _MIN_VOLUME_PARTS = 2
 
-_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}")
+_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([-?])(.*?))?\}")
 
 
 @dataclass(frozen=True)
@@ -76,15 +76,18 @@ def extract_services(compose_data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _interpolate(value: str, env: dict[str, str]) -> str:
-    """Perform ${VAR} and ${VAR:-default} interpolation."""
+    """Perform basic Compose-style variable interpolation."""
 
     def replace(match: re.Match[str]) -> str:
         var = match.group(1)
-        default = match.group(2)
+        operator = match.group(2)
+        fallback = match.group(3)
         resolved = env.get(var)
         if resolved:
             return resolved
-        return default or ""
+        if operator == "-":
+            return fallback or ""
+        return ""
 
     return _VAR_PATTERN.sub(replace, value)
 

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -52,6 +52,36 @@ def test_generate_traefik_config_with_published_port(tmp_path: Path) -> None:
     assert servers == [{"url": "http://192.168.1.10:32400"}]
 
 
+def test_generate_handles_required_ip_var_in_ports(tmp_path: Path) -> None:
+    cfg = Config(
+        compose_dir=tmp_path,
+        hosts={"nas01": Host(address="192.168.1.10")},
+        stacks={"vaultwarden": "nas01"},
+    )
+    compose_path = tmp_path / "vaultwarden" / "docker-compose.yml"
+    _write_compose(
+        compose_path,
+        {
+            "services": {
+                "vaultwarden": {
+                    "ports": ["${DATA_BIND_IP:?bind IP required}:11001:80"],
+                    "labels": [
+                        "traefik.enable=true",
+                        "traefik.http.routers.vaultwarden.rule=Host(`vault.lab.mydomain.org`)",
+                        "traefik.http.services.vaultwarden.loadbalancer.server.port=80",
+                    ],
+                }
+            }
+        },
+    )
+
+    dynamic, warnings = generate_traefik_config(cfg, ["vaultwarden"])
+
+    assert warnings == []
+    servers = dynamic["http"]["services"]["vaultwarden"]["loadbalancer"]["servers"]
+    assert servers == [{"url": "http://192.168.1.10:11001"}]
+
+
 def test_generate_traefik_config_without_published_port_warns(tmp_path: Path) -> None:
     cfg = Config(
         compose_dir=tmp_path,


### PR DESCRIPTION
Summary:
- Recognize Compose required-variable interpolation using the :? operator.
- Preserve :- default handling while avoiding required-message text as a fallback value.
- Add a Traefik regression test for required bind-IP expressions in port mappings.

Testing:
- uv run pytest tests/test_traefik.py::test_generate_handles_required_ip_var_in_ports -q
- uv run pytest tests/test_traefik.py -q
- just lint
- uv run pytest -m "not browser" -n auto