### PR TITLE
preflight: Clean up check diagnostics

### DIFF
--- a/src/compose_farm/executor.py
+++ b/src/compose_farm/executor.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 LOCAL_ADDRESSES = frozenset({"local", "localhost", "127.0.0.1", "::1"})
 _DEFAULT_SSH_PORT = 22
+_REMOTE_CHECK_ATTEMPTS = 2
 
 
 class TTLCache:
@@ -263,8 +264,9 @@ async def _run_local_command(
             stderr=stderr_data.decode() if stderr_data else "",
         )
     except OSError as e:
-        err_console.print(f"{format_stack_prefix(stack)} [red]Local error:[/] {e}")
-        return CommandResult(stack=stack, exit_code=1, success=False)
+        if stream:
+            err_console.print(f"{format_stack_prefix(stack)} [red]Local error:[/] {e}")
+        return CommandResult(stack=stack, exit_code=1, success=False, stderr=str(e))
 
 
 async def _run_ssh_command(
@@ -320,7 +322,8 @@ async def _run_ssh_command(
                     stderr=stderr_data,
                 )
     except (OSError, asyncssh.Error) as e:
-        err_console.print(f"{format_stack_prefix(stack)} [red]SSH error:[/] {e}")
+        if stream:
+            err_console.print(f"{format_stack_prefix(stack)} [red]SSH error:[/] {e}")
         return CommandResult(stack=stack, exit_code=1, success=False, stderr=str(e))
 
 
@@ -668,9 +671,19 @@ async def _batch_check_existence(
         checks.append(cmd_template(escaped))
 
     command = "; ".join(checks)
-    result = await run_command(host, command, context, stream=False)
-    if not result.success:
-        detail = result.stderr or result.stdout or f"exit code {result.exit_code}"
+    result: CommandResult | None = None
+    for attempt in range(_REMOTE_CHECK_ATTEMPTS):
+        result = await run_command(host, command, context, stream=False)
+        if result.success:
+            break
+        if attempt < _REMOTE_CHECK_ATTEMPTS - 1:
+            await asyncio.sleep(0.2)
+
+    if result is None or not result.success:
+        if result is None:
+            detail = "no result"
+        else:
+            detail = result.stderr or result.stdout or f"exit code {result.exit_code}"
         raise RemoteCheckError(host_name, context, detail)
 
     exists: dict[str, bool] = dict.fromkeys(items, False)

--- a/src/compose_farm/traefik.py
+++ b/src/compose_farm/traefik.py
@@ -35,6 +35,7 @@ class _TraefikServiceSource:
     compose_service: str
     host_address: str
     ports: list[PortMapping]
+    requires_published_port: bool = True
     container_port: int | None = None
     scheme: str | None = None
 
@@ -145,6 +146,8 @@ def _finalize_http_services(
     warnings: list[str],
 ) -> None:
     for traefik_service, source in sources.items():
+        if not source.requires_published_port:
+            continue
         published_port, warn = _resolve_published_port(source)
         if warn:
             warnings.append(warn)
@@ -229,6 +232,7 @@ def _process_service_label(
     compose_service: str,
     host_address: str,
     ports: list[PortMapping],
+    requires_published_port: bool,
     service_names: set[str],
     sources: dict[str, _TraefikServiceSource],
 ) -> None:
@@ -249,6 +253,7 @@ def _process_service_label(
             compose_service=compose_service,
             host_address=host_address,
             ports=ports,
+            requires_published_port=requires_published_port,
         )
         sources[traefik_service] = source
 
@@ -266,6 +271,7 @@ def _process_service_labels(
     definition: dict[str, Any],
     all_services: dict[str, Any],
     host_address: str,
+    requires_published_port: bool,
     env: dict[str, str],
     dynamic: dict[str, Any],
     sources: dict[str, _TraefikServiceSource],
@@ -303,6 +309,7 @@ def _process_service_labels(
             compose_service,
             host_address,
             ports,
+            requires_published_port,
             service_names,
             sources,
         )
@@ -333,12 +340,15 @@ def generate_traefik_config(
 
     # Determine Traefik's host from service assignment
     traefik_host = None
-    if config.traefik_stack and not check_all:
+    if config.traefik_stack:
         traefik_host = config.stacks.get(config.traefik_stack)
 
     for stack in stacks:
         raw_services, env, host_address = load_compose_services(config, stack)
         stack_host = config.stacks.get(stack)
+        requires_published_port = not (
+            host_address.lower() in LOCAL_ADDRESSES or (traefik_host and stack_host == traefik_host)
+        )
 
         # Skip stacks on Traefik's host - docker provider handles them directly
         # (unless check_all is True, for validation purposes)
@@ -357,6 +367,7 @@ def generate_traefik_config(
                 definition,
                 raw_services,
                 host_address,
+                requires_published_port,
                 env,
                 dynamic,
                 sources,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -13,6 +13,7 @@ from compose_farm.executor import (
     CommandResult,
     RemoteCheckError,
     _run_local_command,
+    _run_ssh_command,
     _stream_output_lines,
     build_ssh_command,
     check_networks_exist,
@@ -129,6 +130,27 @@ class TestRunCommand:
         assert result.stack == "my-service"
         assert result.exit_code == 0
         assert result.success is True
+
+    async def test_non_streaming_ssh_error_is_returned_not_printed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preflight checks run under progress bars and must not print mid-render."""
+        from compose_farm import executor
+
+        output = _RecordingConsole()
+        monkeypatch.setattr(executor, "err_console", output)
+
+        with patch("asyncssh.connect", side_effect=OSError("Connection lost")):
+            result = await _run_ssh_command(
+                Host(address="192.168.1.10"),
+                "true",
+                "mount-check",
+                stream=False,
+            )
+
+        assert result.success is False
+        assert result.stderr == "Connection lost"
+        assert output.calls == []
 
 
 class TestBuildSshCommand:
@@ -424,6 +446,33 @@ class TestCheckPathsExist:
 
         assert "mount-check failed on remote" in str(exc_info.value)
         assert "Permission denied" in str(exc_info.value)
+
+    async def test_remote_command_failure_retries_once(self, tmp_path: Path) -> None:
+        """Transient SSH failures should not fail the whole preflight immediately."""
+        config = Config(
+            compose_dir=tmp_path,
+            hosts={"remote": Host(address="192.168.1.10")},
+            stacks={},
+        )
+        failed = CommandResult(
+            stack="mount-check",
+            exit_code=1,
+            success=False,
+            stderr="Connection lost",
+        )
+        succeeded = CommandResult(
+            stack="mount-check",
+            exit_code=0,
+            success=True,
+            stdout="Y:/opt/stacks\n",
+        )
+
+        with patch("compose_farm.executor.run_command", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = [failed, succeeded]
+            result = await check_paths_exist(config, "remote", ["/opt/stacks"])
+
+        assert result == {"/opt/stacks": True}
+        assert mock_run.await_count == 2
 
 
 @linux_only

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -110,6 +110,63 @@ def test_generate_traefik_config_without_published_port_warns(tmp_path: Path) ->
     assert any("No published port found" in warning for warning in warnings)
 
 
+def test_check_all_suppresses_same_host_published_port_warning(tmp_path: Path) -> None:
+    cfg = Config(
+        compose_dir=tmp_path,
+        hosts={"nas01": Host(address="192.168.1.10")},
+        stacks={"traefik": "nas01", "app": "nas01"},
+        traefik_stack="traefik",
+    )
+    compose_path = tmp_path / "app" / "docker-compose.yml"
+    _write_compose(
+        compose_path,
+        {
+            "services": {
+                "app": {
+                    "ports": ["8080"],
+                    "labels": [
+                        "traefik.http.routers.app.rule=Host(`app.lab.mydomain.org`)",
+                        "traefik.http.services.app.loadbalancer.server.port=8080",
+                    ],
+                }
+            }
+        },
+    )
+
+    dynamic, warnings = generate_traefik_config(cfg, ["app"], check_all=True)
+
+    assert dynamic["http"]["routers"]["app"]["rule"] == "Host(`app.lab.mydomain.org`)"
+    assert warnings == []
+
+
+def test_check_all_warns_for_remote_stack_without_published_port(tmp_path: Path) -> None:
+    cfg = Config(
+        compose_dir=tmp_path,
+        hosts={"nas01": Host(address="192.168.1.10"), "hp": Host(address="192.168.1.20")},
+        stacks={"traefik": "nas01", "app": "hp"},
+        traefik_stack="traefik",
+    )
+    compose_path = tmp_path / "app" / "docker-compose.yml"
+    _write_compose(
+        compose_path,
+        {
+            "services": {
+                "app": {
+                    "ports": ["8080"],
+                    "labels": [
+                        "traefik.http.routers.app.rule=Host(`app.lab.mydomain.org`)",
+                        "traefik.http.services.app.loadbalancer.server.port=8080",
+                    ],
+                }
+            }
+        },
+    )
+
+    _, warnings = generate_traefik_config(cfg, ["app"], check_all=True)
+
+    assert any("No published port found" in warning for warning in warnings)
+
+
 def test_generate_interpolates_env_and_infers_router_service(tmp_path: Path) -> None:
     cfg = Config(
         compose_dir=tmp_path,


### PR DESCRIPTION
## Summary
- keep non-streaming SSH/local execution errors out of Rich progress rendering and return them through `CommandResult.stderr`
- retry batched remote preflight probes once to absorb transient SSH connection resets
- suppress cross-host published-port warnings for stacks assigned to the Traefik host while preserving warnings for remote stacks

## Validation
- `uv run pytest tests/test_executor.py::TestRunCommand::test_non_streaming_ssh_error_is_returned_not_printed tests/test_executor.py::TestCheckPathsExist::test_remote_command_failure_raises tests/test_executor.py::TestCheckPathsExist::test_remote_command_failure_retries_once tests/test_traefik.py::test_generate_traefik_config_without_published_port_warns tests/test_traefik.py::test_check_all_suppresses_same_host_published_port_warning tests/test_traefik.py::test_check_all_warns_for_remote_stack_without_published_port`
- `just lint`
- `uv run pytest -m "not browser" -n auto`
- `uv run cf check --config /opt/stacks/compose-farm.yaml`

## Notes
This addresses the corrupted `cf check` output where `[mount-check] SSH error: ...` could print into the active progress bar. The check command now reports remote failures only in the final grouped section.