### PR TITLE
cli: Include host in stack failures

### DIFF
--- a/src/compose_farm/cli/common.py
+++ b/src/compose_farm/cli/common.py
@@ -220,12 +220,16 @@ def report_results(results: list[CommandResult]) -> None:
     succeeded = [r for r in results if r.success]
     failed = [r for r in results if not r.success]
 
+    def failure_message(result: CommandResult) -> str:
+        host = f" on [cyan]{result.host}[/]" if result.host else ""
+        return f"[cyan]{result.stack}[/] failed with exit code {result.exit_code}{host}"
+
     # Always print summary when there are multiple results
     if len(results) > 1:
         console.print()  # Blank line before summary
         if failed:
             for r in failed:
-                print_error(f"[cyan]{r.stack}[/] failed with exit code {r.exit_code}")
+                print_error(failure_message(r))
             console.print()
             console.print(
                 f"[green]✓[/] {len(succeeded)}/{len(results)} stacks succeeded, "
@@ -237,7 +241,7 @@ def report_results(results: list[CommandResult]) -> None:
     elif failed:
         # Single stack failed
         r = failed[0]
-        print_error(f"[cyan]{r.stack}[/] failed with exit code {r.exit_code}")
+        print_error(failure_message(r))
 
     if failed:
         raise typer.Exit(1)

--- a/src/compose_farm/executor.py
+++ b/src/compose_farm/executor.py
@@ -157,6 +157,7 @@ class CommandResult:
     success: bool
     stdout: str = ""
     stderr: str = ""
+    host: str = ""
 
     # SSH returns 255 when connection is closed unexpectedly (e.g., Ctrl+C)
     _SSH_CONNECTION_CLOSED = 255
@@ -375,7 +376,9 @@ async def run_compose(
 
     # Use cd to let docker compose find the compose file on the remote host
     command = f'cd "{stack_dir}" && docker compose {compose_cmd}'
-    return await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
+    result = await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
+    result.host = host_name
+    return result
 
 
 async def run_compose_on_host(
@@ -399,7 +402,9 @@ async def run_compose_on_host(
 
     # Use cd to let docker compose find the compose file on the remote host
     command = f'cd "{stack_dir}" && docker compose {compose_cmd}'
-    return await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
+    result = await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
+    result.host = host_name
+    return result
 
 
 async def run_on_stacks(
@@ -436,7 +441,7 @@ async def _run_sequential_stack_commands(
         result = await run_compose(config, stack, cmd, stream=stream, raw=raw, prefix=prefix)
         if not result.success:
             return result
-    return CommandResult(stack=stack, exit_code=0, success=True)
+    return CommandResult(stack=stack, exit_code=0, success=True, host=config.get_hosts(stack)[0])
 
 
 async def _run_sequential_stack_commands_on_host(
@@ -461,9 +466,10 @@ async def _run_sequential_stack_commands_on_host(
         _print_compose_command(host_name, stack, cmd)
         command = f'cd "{stack_dir}" && docker compose {cmd}'
         result = await run_command(host, command, label, stream=stream, raw=raw, prefix=prefix)
+        result.host = host_name
         if not result.success:
             return result
-    return CommandResult(stack=label, exit_code=0, success=True)
+    return CommandResult(stack=label, exit_code=0, success=True, host=host_name)
 
 
 async def _run_sequential_stack_commands_multi_host(
@@ -497,10 +503,17 @@ async def _run_sequential_stack_commands_multi_host(
             # (ignore empty prefix from single-stack batches - we still need to distinguish hosts)
             effective_prefix = label if len(host_names) > 1 else prefix
             tasks.append(
-                run_command(host, command, label, stream=stream, raw=raw, prefix=effective_prefix)
+                (
+                    host_name,
+                    run_command(
+                        host, command, label, stream=stream, raw=raw, prefix=effective_prefix
+                    ),
+                )
             )
 
-        results = await asyncio.gather(*tasks)
+        results = await asyncio.gather(*(task for _, task in tasks))
+        for (host_name, _), result in zip(tasks, results, strict=True):
+            result.host = host_name
         final_results = list(results)
 
         # Check if any failed

--- a/src/compose_farm/operations.py
+++ b/src/compose_farm/operations.py
@@ -247,7 +247,11 @@ async def _up_multi_host_stack(
         preflight = await check_stack_requirements(cfg, stack, host_name)
         if not preflight.ok:
             _report_preflight_failures(stack, host_name, preflight)
-            results.append(CommandResult(stack=f"{stack}@{host_name}", exit_code=1, success=False))
+            results.append(
+                CommandResult(
+                    stack=f"{stack}@{host_name}", exit_code=1, success=False, host=host_name
+                )
+            )
             return results
 
     # Start on all hosts
@@ -259,6 +263,7 @@ async def _up_multi_host_stack(
         host = cfg.hosts[host_name]
         label = f"{stack}@{host_name}"
         result = await run_command(host, command, label, stream=not raw, raw=raw)
+        result.host = host_name
         if raw:
             print()  # Ensure newline after raw output
         results.append(result)
@@ -324,7 +329,7 @@ async def _up_single_stack(
     preflight = await check_stack_requirements(cfg, stack, target_host)
     if not preflight.ok:
         _report_preflight_failures(stack, target_host, preflight)
-        return CommandResult(stack=stack, exit_code=1, success=False)
+        return CommandResult(stack=stack, exit_code=1, success=False, host=target_host)
 
     # If stack is deployed elsewhere, migrate it
     did_migration = False
@@ -377,7 +382,7 @@ async def _up_stack_simple(
     preflight = await check_stack_requirements(cfg, stack, target_host)
     if not preflight.ok:
         _report_preflight_failures(stack, target_host, preflight)
-        return CommandResult(stack=stack, exit_code=1, success=False)
+        return CommandResult(stack=stack, exit_code=1, success=False, host=target_host)
 
     # Run with streaming for parallel output
     result = await run_compose(cfg, stack, build_up_cmd(pull=pull, build=build), raw=raw)
@@ -525,6 +530,7 @@ async def _stop_stacks_on_hosts(
                         exit_code=1,
                         success=False,
                         stderr="host no longer in config",
+                        host=host,
                     )
                 )
                 continue
@@ -547,6 +553,7 @@ async def _stop_stacks_on_hosts(
                     exit_code=1,
                     success=False,
                     stderr=str(e),
+                    host=host,
                 )
             )
 

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,0 +1,34 @@
+"""Tests for shared CLI helpers."""
+
+import pytest
+import typer
+
+from compose_farm.cli.common import report_results
+from compose_farm.executor import CommandResult
+
+
+def test_report_results_includes_host_for_failed_stack(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [
+        CommandResult(stack="clip-files-ui", exit_code=1, success=False, host="hp"),
+        CommandResult(stack="uptime", exit_code=0, success=True, host="nuc"),
+    ]
+
+    with pytest.raises(typer.Exit):
+        report_results(results)
+
+    captured = capsys.readouterr()
+    assert "clip-files-ui failed with exit code 1 on hp" in captured.err
+    assert "1/2 stacks succeeded" in captured.out
+
+
+def test_report_results_keeps_old_format_without_host(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit):
+        report_results([CommandResult(stack="clip-files-ui", exit_code=1, success=False)])
+
+    captured = capsys.readouterr()
+    assert "clip-files-ui failed with exit code 1" in captured.err
+    assert "on " not in captured.err

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -237,6 +237,7 @@ class TestRunCompose:
 
             # Should succeed - docker compose on remote will find the file
             assert result.success
+            assert result.host == "remote"
             # Command should use cd pattern, not -f with a specific file
             command = mock_run.call_args[0][1]
             assert "cd " in command
@@ -254,10 +255,11 @@ class TestRunCompose:
         mock_result = CommandResult(stack="mystack", exit_code=0, success=True)
         with patch("compose_farm.executor.run_command", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = mock_result
-            await run_compose_on_host(config, "mystack", "host1", "down", stream=False)
+            result = await run_compose_on_host(config, "mystack", "host1", "down", stream=False)
 
             command = mock_run.call_args[0][1]
             assert command == f'cd "{tmp_path}/mystack" && docker compose down'
+            assert result.host == "host1"
 
     async def test_check_stack_running_uses_cd_pattern(self, tmp_path: Path) -> None:
         """Verify check_stack_running uses 'cd <dir> && docker compose' pattern."""
@@ -338,6 +340,7 @@ class TestRunOnStacks:
             # Result should be for the filtered host
             assert len(results) == 1
             assert results[0].stack == "multi-svc@host1"
+            assert results[0].host == "host1"
 
     async def test_run_on_stacks_no_filter_runs_all_hosts(self) -> None:
         """Without filter_host, multi-host stacks run on all configured hosts."""

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -18,6 +18,7 @@ from compose_farm.operations import (
     build_discovery_results,
     build_up_cmd,
     check_stack_requirements,
+    up_stacks,
 )
 
 
@@ -173,6 +174,26 @@ class TestPreflightRequirements:
         assert "remote check failed" in captured.err
         assert "Permission denied" in captured.err
         assert "missing path" not in captured.err
+
+    async def test_up_stacks_preflight_failure_includes_host(
+        self,
+        basic_config: Config,
+    ) -> None:
+        """Synthetic preflight failures should still report the target host."""
+        preflight = PreflightResult(
+            missing_paths=["/mnt/data/test-service"],
+            missing_networks=[],
+            missing_devices=[],
+            check_errors=[],
+        )
+
+        with patch("compose_farm.operations.check_stack_requirements", return_value=preflight):
+            results = await up_stacks(basic_config, ["test-service"])
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert results[0].stack == "test-service"
+        assert results[0].host == "host2"
 
 
 class TestUpdateCommandSequence:


### PR DESCRIPTION
## Summary
- add a `host` string to `CommandResult` for stack-operation context
- populate host context for compose stack execution, preflight failures, multi-host starts, and orphan/stray cleanup failures
- include the host in failure summaries, e.g. `clip-files-ui failed with exit code 1 on hp`

## Design note
`host` defaults to an empty string for low-level/generic command results where there is no compose-farm host name. Stack-operation paths now set it explicitly.

## Validation
- `uv run pytest tests/test_cli_common.py tests/test_executor.py::TestRunCompose::test_run_compose_works_without_local_compose_file tests/test_executor.py::TestRunCompose::test_run_compose_on_host_uses_cd_pattern tests/test_executor.py::TestRunOnStacks::test_run_on_stacks_filter_host_limits_multi_host tests/test_operations.py::TestPreflightRequirements::test_up_stacks_preflight_failure_includes_host`
- `just lint`
- `uv run pytest -m "not browser" -n auto`