### PR TITLE
cli: Avoid raw output for host batches

### DIFF
--- a/src/compose_farm/cli/lifecycle.py
+++ b/src/compose_farm/cli/lifecycle.py
@@ -77,12 +77,13 @@ def up(
     elif host:
         # For host-filtered up, use run_on_stacks to only affect that host
         # (skips migration logic, which is intended when explicitly specifying a host)
+        raw = len(stack_list) == 1
         results = run_async(
             run_on_stacks(
                 cfg,
                 stack_list,
                 build_up_cmd(pull=pull, build=build),
-                raw=True,
+                raw=raw,
                 filter_host=host,
             )
         )

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 import typer
 
-from compose_farm.cli.lifecycle import apply, down, pull, restart, stop, update
+from compose_farm.cli.lifecycle import apply, down, pull, restart, stop, up, update
 from compose_farm.config import Config, Host
 from compose_farm.executor import CommandResult
 
@@ -501,6 +501,57 @@ class TestLifecycleHostFilters:
         assert set(mock_run.call_args.args[1]) == {"svc1", "multi"}
         assert mock_run.call_args.args[2] == compose_cmd
         assert mock_run.call_args.kwargs.get("filter_host") == "host1"
+
+    def test_up_host_filter_multiple_stacks_disables_raw_output(self, tmp_path: Path) -> None:
+        """BuildKit/progress output corrupts the terminal when raw output runs in parallel."""
+        cfg = _make_config(
+            tmp_path,
+            {
+                "svc1": "host1",
+                "svc2": "host2",
+                "multi": ["host1", "host2"],
+            },
+        )
+
+        with (
+            patch("compose_farm.cli.common.load_config_or_exit", return_value=cfg),
+            patch("compose_farm.cli.lifecycle.run_on_stacks") as mock_run,
+            patch(
+                "compose_farm.cli.lifecycle.run_async",
+                side_effect=_run_async_returns([_make_result("svc1"), _make_result("multi@host1")]),
+            ),
+            patch("compose_farm.cli.lifecycle.add_stack_host"),
+            patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
+            patch("compose_farm.cli.lifecycle.report_results"),
+        ):
+            up(stacks=None, all_stacks=False, host="host1", service=None, config=None)
+
+        mock_run.assert_called_once()
+        assert set(mock_run.call_args.args[1]) == {"svc1", "multi"}
+        assert mock_run.call_args.kwargs.get("filter_host") == "host1"
+        assert mock_run.call_args.kwargs.get("raw") is False
+
+    def test_up_host_filter_single_stack_keeps_raw_output(self, tmp_path: Path) -> None:
+        """Single-stack host-filtered up can keep TTY progress rendering."""
+        cfg = _make_config(tmp_path, {"svc1": "host1", "svc2": "host2"})
+
+        with (
+            patch("compose_farm.cli.common.load_config_or_exit", return_value=cfg),
+            patch("compose_farm.cli.lifecycle.run_on_stacks") as mock_run,
+            patch(
+                "compose_farm.cli.lifecycle.run_async",
+                side_effect=_run_async_returns([_make_result("svc1")]),
+            ),
+            patch("compose_farm.cli.lifecycle.add_stack_host"),
+            patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
+            patch("compose_farm.cli.lifecycle.report_results"),
+        ):
+            up(stacks=None, all_stacks=False, host="host2", service=None, config=None)
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args.args[1] == ["svc2"]
+        assert mock_run.call_args.kwargs.get("filter_host") == "host2"
+        assert mock_run.call_args.kwargs.get("raw") is True
 
     def test_update_forwards_host_to_up(self) -> None:
         """Update --host uses up --host with pull/build enabled."""


### PR DESCRIPTION
## Summary
- disable raw terminal output when a host-filtered `up` selects multiple stacks
- keep raw Docker progress output for single-stack host-filtered `up`
- add lifecycle tests for both host-filtered batch and single-stack behavior

## Why
`cf update -H hp` delegates to host-filtered `up`. When multiple stacks are selected, raw Docker/BuildKit progress streams run in parallel and corrupt the terminal output. Managed output is the safer default for host batches, while preserving raw TTY progress for the single-stack case.

## Validation
- `uv run pytest -m "not browser" -n auto -q`
- `just lint`