### PR TITLE
executor: Separate result labels from stack identity

### DIFF
--- a/src/compose_farm/cli/common.py
+++ b/src/compose_farm/cli/common.py
@@ -222,7 +222,8 @@ def report_results(results: list[CommandResult]) -> None:
 
     def failure_message(result: CommandResult) -> str:
         host = f" on [cyan]{result.host}[/]" if result.host else ""
-        return f"[cyan]{result.stack}[/] failed with exit code {result.exit_code}{host}"
+        name = result.stack if result.host else result.display_label
+        return f"[cyan]{name}[/] failed with exit code {result.exit_code}{host}"
 
     # Always print summary when there are multiple results
     if len(results) > 1:

--- a/src/compose_farm/cli/lifecycle.py
+++ b/src/compose_farm/cli/lifecycle.py
@@ -90,8 +90,7 @@ def up(
         # Update state for successful host-filtered operations
         for result in results:
             if result.success:
-                base_stack = result.stack.split("@")[0]
-                add_stack_host(cfg, base_stack, host)
+                add_stack_host(cfg, result.stack, result.host or host)
     else:
         results = run_async(up_stacks(cfg, stack_list, raw=True, pull=pull, build=build))
     maybe_regenerate_traefik(cfg, results)
@@ -138,17 +137,16 @@ def down(
     results = run_async(run_on_stacks(cfg, stack_list, "down", raw=raw, filter_host=host))
 
     # Update state on success
-    # For multi-host stacks, result.stack is "stack@host", extract base name
-    updated_stacks: set[str] = set()
+    updated_stacks: set[tuple[str, str | None]] = set()
     for result in results:
         if result.success:
-            base_stack = result.stack.split("@")[0]
-            if base_stack not in updated_stacks:
-                # When host is specified for multi-host stack, removes just that host
-                # Otherwise removes entire stack from state
-                filter_host = host if host and cfg.is_multi_host(base_stack) else None
-                remove_stack(cfg, base_stack, filter_host)
-                updated_stacks.add(base_stack)
+            # For multi-host stacks, remove only the host that actually succeeded.
+            # Single-host stacks can be removed as a whole.
+            filter_host = result.host if cfg.is_multi_host(result.stack) else None
+            key = (result.stack, filter_host)
+            if key not in updated_stacks:
+                remove_stack(cfg, result.stack, filter_host)
+                updated_stacks.add(key)
 
     maybe_regenerate_traefik(cfg, results)
     report_results(results)

--- a/src/compose_farm/executor.py
+++ b/src/compose_farm/executor.py
@@ -158,6 +158,7 @@ class CommandResult:
     stdout: str = ""
     stderr: str = ""
     host: str = ""
+    label: str = ""
 
     # SSH returns 255 when connection is closed unexpectedly (e.g., Ctrl+C)
     _SSH_CONNECTION_CLOSED = 255
@@ -167,6 +168,11 @@ class CommandResult:
         """Check if command was killed by SIGINT (Ctrl+C)."""
         # Negative exit codes indicate signal termination; -2 = SIGINT
         return self.exit_code < 0 or self.exit_code == self._SSH_CONNECTION_CLOSED
+
+    @property
+    def display_label(self) -> str:
+        """Return the label to use when this result needs display context."""
+        return self.label or self.stack
 
 
 class RemoteCheckError(RuntimeError):
@@ -266,7 +272,7 @@ async def _run_local_command(
         )
     except OSError as e:
         if stream:
-            err_console.print(f"{format_stack_prefix(stack)} [red]Local error:[/] {e}")
+            err_console.print(f"{format_stack_prefix(prefix or stack)} [red]Local error:[/] {e}")
         return CommandResult(stack=stack, exit_code=1, success=False, stderr=str(e))
 
 
@@ -324,7 +330,7 @@ async def _run_ssh_command(
                 )
     except (OSError, asyncssh.Error) as e:
         if stream:
-            err_console.print(f"{format_stack_prefix(stack)} [red]SSH error:[/] {e}")
+            err_console.print(f"{format_stack_prefix(prefix or stack)} [red]SSH error:[/] {e}")
         return CommandResult(stack=stack, exit_code=1, success=False, stderr=str(e))
 
 
@@ -378,6 +384,7 @@ async def run_compose(
     command = f'cd "{stack_dir}" && docker compose {compose_cmd}'
     result = await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
     result.host = host_name
+    result.label = stack
     return result
 
 
@@ -404,6 +411,7 @@ async def run_compose_on_host(
     command = f'cd "{stack_dir}" && docker compose {compose_cmd}'
     result = await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
     result.host = host_name
+    result.label = f"{stack}@{host_name}"
     return result
 
 
@@ -465,11 +473,12 @@ async def _run_sequential_stack_commands_on_host(
     for cmd in commands:
         _print_compose_command(host_name, stack, cmd)
         command = f'cd "{stack_dir}" && docker compose {cmd}'
-        result = await run_command(host, command, label, stream=stream, raw=raw, prefix=prefix)
+        result = await run_command(host, command, stack, stream=stream, raw=raw, prefix=prefix)
         result.host = host_name
+        result.label = label
         if not result.success:
             return result
-    return CommandResult(stack=label, exit_code=0, success=True, host=host_name)
+    return CommandResult(stack=stack, exit_code=0, success=True, host=host_name, label=label)
 
 
 async def _run_sequential_stack_commands_multi_host(
@@ -506,7 +515,7 @@ async def _run_sequential_stack_commands_multi_host(
                 (
                     host_name,
                     run_command(
-                        host, command, label, stream=stream, raw=raw, prefix=effective_prefix
+                        host, command, stack, stream=stream, raw=raw, prefix=effective_prefix
                     ),
                 )
             )
@@ -514,6 +523,7 @@ async def _run_sequential_stack_commands_multi_host(
         results = await asyncio.gather(*(task for _, task in tasks))
         for (host_name, _), result in zip(tasks, results, strict=True):
             result.host = host_name
+            result.label = f"{stack}@{host_name}" if len(host_names) > 1 else stack
         final_results = list(results)
 
         # Check if any failed

--- a/src/compose_farm/operations.py
+++ b/src/compose_farm/operations.py
@@ -249,7 +249,11 @@ async def _up_multi_host_stack(
             _report_preflight_failures(stack, host_name, preflight)
             results.append(
                 CommandResult(
-                    stack=f"{stack}@{host_name}", exit_code=1, success=False, host=host_name
+                    stack=stack,
+                    exit_code=1,
+                    success=False,
+                    host=host_name,
+                    label=f"{stack}@{host_name}",
                 )
             )
             return results
@@ -262,8 +266,9 @@ async def _up_multi_host_stack(
     for host_name in host_names:
         host = cfg.hosts[host_name]
         label = f"{stack}@{host_name}"
-        result = await run_command(host, command, label, stream=not raw, raw=raw)
+        result = await run_command(host, command, stack, stream=not raw, raw=raw, prefix=label)
         result.host = host_name
+        result.label = label
         if raw:
             print()  # Ensure newline after raw output
         results.append(result)
@@ -526,11 +531,12 @@ async def _stop_stacks_on_hosts(
                 print_warning(f"{stack}@{host}: host no longer in config, skipping")
                 results.append(
                     CommandResult(
-                        stack=f"{stack}@{host}",
+                        stack=stack,
                         exit_code=1,
                         success=False,
                         stderr="host no longer in config",
                         host=host,
+                        label=f"{stack}@{host}",
                     )
                 )
                 continue
@@ -549,11 +555,12 @@ async def _stop_stacks_on_hosts(
             print_error(f"{stack}@{host}: {e}")
             results.append(
                 CommandResult(
-                    stack=f"{stack}@{host}",
+                    stack=stack,
                     exit_code=1,
                     success=False,
                     stderr=str(e),
                     host=host,
+                    label=f"{stack}@{host}",
                 )
             )
 
@@ -579,9 +586,12 @@ async def stop_orphaned_stacks(cfg: Config) -> list[CommandResult]:
     results = await _stop_stacks_on_hosts(cfg, normalized)
 
     # Remove from state only for stacks where ALL hosts succeeded
-    for stack in normalized:
-        all_succeeded = all(
-            r.success for r in results if r.stack.startswith(f"{stack}@") or r.stack == stack
+    for stack, hosts in normalized.items():
+        expected_hosts = set(hosts)
+        matching_results = [r for r in results if r.stack == stack and r.host in expected_hosts]
+        all_succeeded = (
+            all(r.success for r in matching_results)
+            and {r.host for r in matching_results} == expected_hosts
         )
         if all_succeeded:
             remove_stack(cfg, stack)
@@ -600,7 +610,7 @@ async def stop_stray_stacks(
         strays: Dict mapping stack name to list of stray hosts.
 
     Returns:
-        List of CommandResults for each stack@host stopped.
+        List of CommandResults for each stack/host stopped.
 
     """
     return await _stop_stacks_on_hosts(cfg, strays, label="stray")

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -32,3 +32,15 @@ def test_report_results_keeps_old_format_without_host(
     captured = capsys.readouterr()
     assert "clip-files-ui failed with exit code 1" in captured.err
     assert "on " not in captured.err
+
+
+def test_report_results_uses_display_label_without_host(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit):
+        report_results(
+            [CommandResult(stack="multi", exit_code=1, success=False, label="multi@host1")]
+        )
+
+    captured = capsys.readouterr()
+    assert "multi@host1 failed with exit code 1" in captured.err

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 import typer
@@ -37,7 +37,13 @@ def _make_config(tmp_path: Path, stacks: dict[str, str | list[str]] | None = Non
     )
 
 
-def _make_result(stack: str, success: bool = True) -> CommandResult:
+def _make_result(
+    stack: str,
+    success: bool = True,
+    *,
+    host: str = "",
+    label: str = "",
+) -> CommandResult:
     """Create a command result."""
     return CommandResult(
         stack=stack,
@@ -45,6 +51,8 @@ def _make_result(stack: str, success: bool = True) -> CommandResult:
         success=success,
         stdout="",
         stderr="",
+        host=host,
+        label=label,
     )
 
 
@@ -146,7 +154,7 @@ class TestApplyCommand:
     def test_apply_executes_orphan_cleanup(self, tmp_path: Path) -> None:
         """Apply stops orphaned stacks."""
         cfg = _make_config(tmp_path)
-        mock_results = [_make_result("old-svc@host1")]
+        mock_results = [_make_result("old-svc", host="host1", label="old-svc@host1")]
 
         with (
             patch("compose_farm.cli.lifecycle.load_config_or_exit", return_value=cfg),
@@ -388,7 +396,7 @@ class TestDownOrphaned:
     def test_down_orphaned_stops_stacks(self, tmp_path: Path) -> None:
         """--orphaned stops orphaned stacks."""
         cfg = _make_config(tmp_path)
-        mock_results = [_make_result("old-svc@host1")]
+        mock_results = [_make_result("old-svc", host="host1", label="old-svc@host1")]
 
         with (
             patch("compose_farm.cli.lifecycle.load_config_or_exit", return_value=cfg),
@@ -485,7 +493,12 @@ class TestLifecycleHostFilters:
             patch("compose_farm.cli.lifecycle.run_on_stacks") as mock_run,
             patch(
                 "compose_farm.cli.lifecycle.run_async",
-                side_effect=_run_async_returns([_make_result("svc1"), _make_result("multi@host1")]),
+                side_effect=_run_async_returns(
+                    [
+                        _make_result("svc1", host="host1"),
+                        _make_result("multi", host="host1", label="multi@host1"),
+                    ]
+                ),
             ),
             patch("compose_farm.cli.lifecycle.report_results"),
         ):
@@ -518,7 +531,12 @@ class TestLifecycleHostFilters:
             patch("compose_farm.cli.lifecycle.run_on_stacks") as mock_run,
             patch(
                 "compose_farm.cli.lifecycle.run_async",
-                side_effect=_run_async_returns([_make_result("svc1"), _make_result("multi@host1")]),
+                side_effect=_run_async_returns(
+                    [
+                        _make_result("svc1", host="host1"),
+                        _make_result("multi", host="host1", label="multi@host1"),
+                    ]
+                ),
             ),
             patch("compose_farm.cli.lifecycle.add_stack_host"),
             patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
@@ -610,7 +628,9 @@ class TestHostFilterMultiHost:
             patch("compose_farm.cli.lifecycle.run_on_stacks") as mock_run,
             patch(
                 "compose_farm.cli.lifecycle.run_async",
-                side_effect=_run_async_returns([_make_result("multi-host@host1")]),
+                side_effect=_run_async_returns(
+                    [_make_result("multi-host", host="host1", label="multi-host@host1")]
+                ),
             ),
             patch("compose_farm.cli.lifecycle.remove_stack"),
             patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
@@ -645,7 +665,9 @@ class TestHostFilterMultiHost:
             patch("compose_farm.cli.lifecycle.run_on_stacks"),
             patch(
                 "compose_farm.cli.lifecycle.run_async",
-                side_effect=_run_async_returns([_make_result("multi-host@host1")]),
+                side_effect=_run_async_returns(
+                    [_make_result("multi-host", host="host1", label="multi-host@host1")]
+                ),
             ),
             patch("compose_farm.cli.lifecycle.remove_stack") as mock_remove,
             patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
@@ -664,8 +686,10 @@ class TestHostFilterMultiHost:
             # remove_stack should be called with the host parameter
             mock_remove.assert_called_once_with(cfg, "multi-host", "host1")
 
-    def test_down_without_host_filter_removes_from_state(self, tmp_path: Path) -> None:
-        """Without --host filter, multi-host stacks SHOULD be removed from state."""
+    def test_down_without_host_filter_removes_successful_hosts_from_state(
+        self, tmp_path: Path
+    ) -> None:
+        """Without --host filter, multi-host stacks remove each successful host."""
         cfg = self._make_multi_host_config(tmp_path)
 
         with (
@@ -676,9 +700,9 @@ class TestHostFilterMultiHost:
                 "compose_farm.cli.lifecycle.run_async",
                 side_effect=_run_async_returns(
                     [
-                        _make_result("multi-host@host1"),
-                        _make_result("multi-host@host2"),
-                        _make_result("multi-host@host3"),
+                        _make_result("multi-host", host="host1", label="multi-host@host1"),
+                        _make_result("multi-host", host="host2", label="multi-host@host2"),
+                        _make_result("multi-host", host="host3", label="multi-host@host3"),
                     ]
                 ),
             ),
@@ -696,5 +720,10 @@ class TestHostFilterMultiHost:
                 config=None,
             )
 
-            # remove_stack SHOULD be called with host=None when stopping all instances
-            mock_remove.assert_called_once_with(cfg, "multi-host", None)
+            # remove_stack should be called once per successful host, preserving
+            # failed hosts in state if a multi-host down partially fails.
+            assert mock_remove.call_args_list == [
+                call(cfg, "multi-host", "host1"),
+                call(cfg, "multi-host", "host2"),
+                call(cfg, "multi-host", "host3"),
+            ]

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -51,9 +51,17 @@ def _make_multi_host_config(tmp_path: Path) -> Config:
     )
 
 
-def _make_result(stack: str) -> CommandResult:
+def _make_result(stack: str, *, host: str = "", label: str = "") -> CommandResult:
     """Create a successful command result."""
-    return CommandResult(stack=stack, exit_code=0, success=True, stdout="", stderr="")
+    return CommandResult(
+        stack=stack,
+        exit_code=0,
+        success=True,
+        stdout="",
+        stderr="",
+        host=host,
+        label=label,
+    )
 
 
 def _mock_run_async_factory(
@@ -232,11 +240,14 @@ class TestLogsHostFilter:
     def test_logs_host_filter_passes_filter_host_to_run_on_stacks(self, tmp_path: Path) -> None:
         """--host should pass filter_host to run_on_stacks for multi-host stacks."""
         cfg = _make_multi_host_config(tmp_path)
-        mock_run_async, _ = _mock_run_async_factory(["multi-host@host1"])
+        result = _make_result("multi-host", host="host1", label="multi-host@host1")
 
         with (
             patch("compose_farm.cli.common.load_config_or_exit", return_value=cfg),
-            patch("compose_farm.cli.monitoring.run_async", side_effect=mock_run_async),
+            patch(
+                "compose_farm.cli.monitoring.run_async",
+                side_effect=lambda coro: (coro.close(), [result])[1],
+            ),
             patch("compose_farm.cli.monitoring.run_on_stacks") as mock_run,
         ):
             logs(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -259,7 +259,9 @@ class TestRunCompose:
 
             command = mock_run.call_args[0][1]
             assert command == f'cd "{tmp_path}/mystack" && docker compose down'
+            assert result.stack == "mystack"
             assert result.host == "host1"
+            assert result.label == "mystack@host1"
 
     async def test_check_stack_running_uses_cd_pattern(self, tmp_path: Path) -> None:
         """Verify check_stack_running uses 'cd <dir> && docker compose' pattern."""
@@ -328,7 +330,7 @@ class TestRunOnStacks:
             stacks={"multi-svc": ["host1", "host2", "host3"]},  # multi-host stack
         )
 
-        mock_result = CommandResult(stack="multi-svc@host1", exit_code=0, success=True)
+        mock_result = CommandResult(stack="multi-svc", exit_code=0, success=True)
         with patch("compose_farm.executor.run_command", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = mock_result
             results = await run_on_stacks(
@@ -337,10 +339,12 @@ class TestRunOnStacks:
 
             # Should only call run_command once (for host1), not 3 times
             assert mock_run.call_count == 1
+            assert mock_run.call_args.args[2] == "multi-svc"
             # Result should be for the filtered host
             assert len(results) == 1
-            assert results[0].stack == "multi-svc@host1"
+            assert results[0].stack == "multi-svc"
             assert results[0].host == "host1"
+            assert results[0].label == "multi-svc@host1"
 
     async def test_run_on_stacks_no_filter_runs_all_hosts(self) -> None:
         """Without filter_host, multi-host stacks run on all configured hosts."""


### PR DESCRIPTION
## Summary
- keep `CommandResult.stack` as the canonical stack name and add an explicit `label`/`display_label` for display-only context
- stop parsing `stack@host` strings in lifecycle state updates
- preserve host-specific display labels for multi-host output and contextual compose operations
- update multi-host `down` state handling to remove only hosts whose stop actually succeeded

## Why
The old result model mixed stack identity with display labels like `stack@host`. That forced callers to recover identity with string parsing and made state updates depend on presentation formatting. This keeps identity, host, and display context separate without introducing a larger wrapper result type yet.

## Validation
- `uv run pytest tests/test_executor.py tests/test_cli_lifecycle.py tests/test_cli_common.py tests/test_cli_logs.py -q`
- `uv run pytest -m "not browser" -n auto -q`
- `just lint`