### PR TITLE
web: Prevent update badges from wrapping

### DIFF
--- a/src/compose_farm/web/routes/containers.py
+++ b/src/compose_farm/web/routes/containers.py
@@ -114,7 +114,8 @@ def _render_update_cell(image: str, tag: str) -> str:
     cached_html = _update_check_cache.get(f"{image}:{tag}")
     inner = cached_html if cached_html is not None else _DASH_HTML
     return (
-        f"""<td class="update-cell" data-image="{encoded_image}" data-tag="{encoded_tag}">"""
+        f"""<td class="update-cell whitespace-nowrap" """
+        f"""data-image="{encoded_image}" data-tag="{encoded_tag}">"""
         f"{inner}</td>"
     )
 
@@ -312,8 +313,9 @@ def _render_update_badge(result: TagCheckResult) -> str:
         title = f"Newer: {', '.join(updates[:3])}" + ("..." if count > 3 else "")  # noqa: PLR2004
         tip = html.escape(title, quote=True)
         return (
-            f'<span class="tooltip" data-tip="{tip}">'
-            f'<span class="badge badge-warning badge-xs cursor-help">{count} new</span>'
+            f'<span class="tooltip whitespace-nowrap" data-tip="{tip}">'
+            f'<span class="badge badge-warning badge-xs cursor-help whitespace-nowrap">'
+            f"{count} new</span>"
             "</span>"
         )
     return '<span class="tooltip" data-tip="Up to date"><span class="text-success text-xs">✓</span></span>'

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -8,11 +8,13 @@ from fastapi.testclient import TestClient
 
 from compose_farm.config import Config, Host
 from compose_farm.glances import ContainerStats, format_bytes
+from compose_farm.registry import ImageRef, TagCheckResult
 from compose_farm.web.app import create_app
 from compose_farm.web.routes.containers import (
     _infer_stack_service,
     _parse_image,
     _parse_uptime_seconds,
+    _render_update_badge,
 )
 
 # Byte size constants for tests
@@ -221,6 +223,7 @@ class TestContainersRowsAPI:
         assert "<tr " in response.text  # <tr id="..."> has attributes
         assert "nginx" in response.text
         assert "running" in response.text
+        assert 'class="update-cell whitespace-nowrap"' in response.text
 
     def test_rows_have_data_sort_attributes(self, client: TestClient) -> None:
         """Test rows have data-sort attributes for client-side sorting."""
@@ -266,3 +269,20 @@ class TestContainersRowsAPI:
             assert 'data-sort="web"' in response.text  # service
             assert 'data-sort="3600"' in response.text  # uptime (1 hour = 3600s)
             assert 'data-sort="10' in response.text  # cpu
+
+
+class TestUpdateBadge:
+    """Tests for container update badge rendering."""
+
+    def test_available_updates_badge_does_not_wrap(self) -> None:
+        html = _render_update_badge(
+            TagCheckResult(
+                image=ImageRef.parse("nginx:1.0.0"),
+                current_digest="",
+                available_updates=["1.0.1", "1.0.2"],
+            )
+        )
+
+        assert "2 new" in html
+        assert "tooltip whitespace-nowrap" in html
+        assert "badge badge-warning badge-xs cursor-help whitespace-nowrap" in html


### PR DESCRIPTION
## Summary
- add `whitespace-nowrap` to Live Stats update cells
- add `whitespace-nowrap` to the `N new` update badge and tooltip wrapper
- cover both generated row HTML and update badge HTML in tests

## Why
In the Live Stats table, update labels like `78 new` could wrap onto two lines in the narrow Update column. The badge should stay as one compact token.

## Validation
- `uv run pytest tests/test_containers.py -q`
- `just lint`
- `uv run pytest -m "not browser" -n auto -q`