### PR TITLE
ci: Ignore Docker cache export failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,4 +108,4 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true


### PR DESCRIPTION
## Summary
- make the Docker build workflow ignore GitHub Actions cache export failures
- keep using the GHA cache when it works, but do not fail release image publishing when cache reservation fails

## Why
The v1.21.3 Docker workflow failed after pushing the version-specific image because BuildKit could not reserve GitHub Actions cache space:

```
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

That left `ghcr.io/basnijholt/compose-farm:1.21.3` pushed, but `1.21`, `1`, and `latest` remained on older digests. Cache export should be best-effort; pushing release image tags is the important part.

## Validation
- `just lint`
- `git diff --check`

## After merge
Rerun the Docker workflow for version `1.21.3` with workflow dispatch so `1.21`, `1`, and `latest` get updated.