### PR TITLE
executor: Disable raw output for multi-host stacks

### DIFF
--- a/src/compose_farm/cli/lifecycle.py
+++ b/src/compose_farm/cli/lifecycle.py
@@ -46,6 +46,11 @@ from compose_farm.state import (
 )
 
 
+def _single_target_raw_output(cfg: Config, stack_list: list[str]) -> bool:
+    """Return whether compose can safely own the terminal for this operation."""
+    return len(stack_list) == 1 and not cfg.is_multi_host(stack_list[0])
+
+
 @app.command(rich_help_panel="Lifecycle")
 def up(
     stacks: StacksArg = None,
@@ -92,7 +97,15 @@ def up(
             if result.success:
                 add_stack_host(cfg, result.stack, result.host or host)
     else:
-        results = run_async(up_stacks(cfg, stack_list, raw=True, pull=pull, build=build))
+        results = run_async(
+            up_stacks(
+                cfg,
+                stack_list,
+                raw=_single_target_raw_output(cfg, stack_list),
+                pull=pull,
+                build=build,
+            )
+        )
     maybe_regenerate_traefik(cfg, results)
     report_results(results)
 

--- a/src/compose_farm/executor.py
+++ b/src/compose_farm/executor.py
@@ -571,6 +571,7 @@ async def _run_sequential_stack_commands_multi_host(
         # Use cd to let docker compose find the compose file on the remote host
         command = f'cd "{stack_dir}" && docker compose {cmd}'
         tasks = []
+        use_raw = raw and len(host_names) == 1
         for host_name in host_names:
             _print_compose_command(host_name, stack, cmd)
             host = config.hosts[host_name]
@@ -584,8 +585,8 @@ async def _run_sequential_stack_commands_multi_host(
                     host,
                     command,
                     stack,
-                    stream=stream,
-                    raw=raw,
+                    stream=stream and not use_raw,
+                    raw=use_raw,
                     prefix=effective_prefix,
                     host_name=host_name,
                     label=label,

--- a/src/compose_farm/operations.py
+++ b/src/compose_farm/operations.py
@@ -263,6 +263,7 @@ async def _up_multi_host_stack(
     console.print(f"{prefix} Starting on {hosts_str}...")
 
     succeeded_hosts: list[str] = []
+    use_raw = raw and len(host_names) == 1
     for host_name in host_names:
         host = cfg.hosts[host_name]
         label = f"{stack}@{host_name}"
@@ -270,13 +271,13 @@ async def _up_multi_host_stack(
             host,
             command,
             stack,
-            stream=not raw,
-            raw=raw,
+            stream=not use_raw,
+            raw=use_raw,
             prefix=label,
             host_name=host_name,
             label=label,
         )
-        if raw:
+        if use_raw:
             print()  # Ensure newline after raw output
         results.append(result)
         if result.success:
@@ -457,7 +458,12 @@ async def up_stacks(
             multi_results = await asyncio.gather(
                 *[
                     _up_multi_host_stack(
-                        cfg, stack, format_stack_prefix(stack), raw=raw, pull=pull, build=build
+                        cfg,
+                        stack,
+                        format_stack_prefix(stack),
+                        raw=False,
+                        pull=pull,
+                        build=build,
                     )
                     for stack in multi_host
                 ]

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -571,6 +571,57 @@ class TestLifecycleHostFilters:
         assert mock_run.call_args.kwargs.get("filter_host") == "host2"
         assert mock_run.call_args.kwargs.get("raw") is True
 
+    def test_up_all_with_multi_host_stack_disables_raw_output(self, tmp_path: Path) -> None:
+        """A multi-host stack fans out to several compose processes, so raw TTY output is unsafe."""
+        cfg = _make_config(tmp_path, {"svc1": "host1", "glances": ["host1", "host2"]})
+
+        with (
+            patch("compose_farm.cli.common.load_config_or_exit", return_value=cfg),
+            patch("compose_farm.cli.lifecycle.up_stacks") as mock_up,
+            patch(
+                "compose_farm.cli.lifecycle.run_async",
+                side_effect=_run_async_returns(
+                    [
+                        _make_result("svc1", host="host1"),
+                        _make_result("glances", host="host1", label="glances@host1"),
+                        _make_result("glances", host="host2", label="glances@host2"),
+                    ]
+                ),
+            ),
+            patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
+            patch("compose_farm.cli.lifecycle.report_results"),
+        ):
+            up(stacks=None, all_stacks=True, host=None, service=None, config=None)
+
+        mock_up.assert_called_once()
+        assert set(mock_up.call_args.args[1]) == {"svc1", "glances"}
+        assert mock_up.call_args.kwargs.get("raw") is False
+
+    def test_up_single_multi_host_stack_disables_raw_output(self, tmp_path: Path) -> None:
+        """One stack name can still mean multiple concurrent host commands."""
+        cfg = _make_config(tmp_path, {"glances": ["host1", "host2"]})
+
+        with (
+            patch("compose_farm.cli.common.load_config_or_exit", return_value=cfg),
+            patch("compose_farm.cli.lifecycle.up_stacks") as mock_up,
+            patch(
+                "compose_farm.cli.lifecycle.run_async",
+                side_effect=_run_async_returns(
+                    [
+                        _make_result("glances", host="host1", label="glances@host1"),
+                        _make_result("glances", host="host2", label="glances@host2"),
+                    ]
+                ),
+            ),
+            patch("compose_farm.cli.lifecycle.maybe_regenerate_traefik"),
+            patch("compose_farm.cli.lifecycle.report_results"),
+        ):
+            up(stacks=["glances"], all_stacks=False, host=None, service=None, config=None)
+
+        mock_up.assert_called_once()
+        assert mock_up.call_args.args[1] == ["glances"]
+        assert mock_up.call_args.kwargs.get("raw") is False
+
     def test_update_forwards_host_to_up(self) -> None:
         """Update --host uses up --host with pull/build enabled."""
         with patch("compose_farm.cli.lifecycle.up") as mock_up:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -368,6 +368,51 @@ class TestRunOnStacks:
             # Results should be for both hosts
             assert len(results) == 2
 
+    async def test_run_on_stacks_multi_host_disables_raw_output(self) -> None:
+        """Raw TTY output is unsafe when one stack fans out to multiple hosts."""
+        config = Config(
+            compose_dir=Path("/tmp"),
+            hosts={
+                "host1": Host(address="192.168.1.1"),
+                "host2": Host(address="192.168.1.2"),
+            },
+            stacks={"glances": ["host1", "host2"]},
+        )
+
+        mock_result = CommandResult(stack="glances", exit_code=0, success=True)
+        with patch("compose_farm.executor.run_command", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = mock_result
+            await run_on_stacks(config, ["glances"], "up -d --pull always", raw=True)
+
+        assert mock_run.call_count == 2
+        assert all(call.kwargs["raw"] is False for call in mock_run.call_args_list)
+        assert all(call.kwargs["stream"] is True for call in mock_run.call_args_list)
+
+    async def test_run_on_stacks_multi_host_filter_keeps_raw_output(self) -> None:
+        """A host filter reduces a multi-host stack to one compose process."""
+        config = Config(
+            compose_dir=Path("/tmp"),
+            hosts={
+                "host1": Host(address="192.168.1.1"),
+                "host2": Host(address="192.168.1.2"),
+            },
+            stacks={"glances": ["host1", "host2"]},
+        )
+
+        mock_result = CommandResult(stack="glances", exit_code=0, success=True)
+        with patch("compose_farm.executor.run_command", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = mock_result
+            await run_on_stacks(
+                config,
+                ["glances"],
+                "up -d --pull always",
+                raw=True,
+                filter_host="host1",
+            )
+
+        mock_run.assert_awaited_once()
+        assert mock_run.call_args.kwargs["raw"] is True
+
 
 @linux_only
 class TestCheckPathsExist:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -194,6 +194,43 @@ class TestPreflightRequirements:
         assert results[0].success is False
         assert results[0].stack == "test-service"
         assert results[0].host == "host2"
+
+    async def test_up_stacks_multi_host_forces_streamed_output(self, tmp_path: Path) -> None:
+        """Even raw=True must not allocate multiple compose TTY renderers."""
+        compose_dir = tmp_path / "compose"
+        (compose_dir / "glances").mkdir(parents=True)
+        (compose_dir / "glances" / "docker-compose.yml").write_text("services: {}\n")
+        cfg = Config(
+            compose_dir=compose_dir,
+            hosts={
+                "host1": Host(address="192.168.1.1"),
+                "host2": Host(address="192.168.1.2"),
+            },
+            stacks={"glances": ["host1", "host2"]},
+        )
+        preflight = PreflightResult([], [], [], [])
+
+        async def run_result(*args: object, **kwargs: object) -> CommandResult:
+            return CommandResult(
+                stack="glances",
+                exit_code=0,
+                success=True,
+                host=str(kwargs.get("host_name", "")),
+                label=str(kwargs.get("label", "")),
+            )
+
+        with (
+            patch("compose_farm.operations.check_stack_requirements", return_value=preflight),
+            patch("compose_farm.operations.run_command", new_callable=AsyncMock) as mock_run,
+            patch("compose_farm.operations.set_multi_host_stack"),
+        ):
+            mock_run.side_effect = run_result
+            results = await up_stacks(cfg, ["glances"], raw=True, pull=True, build=True)
+
+        assert len(results) == 2
+        assert all(result.success for result in results)
+        assert all(call.kwargs["raw"] is False for call in mock_run.call_args_list)
+        assert all(call.kwargs["stream"] is True for call in mock_run.call_args_list)
 
 
 class TestUpdateCommandSequence:


### PR DESCRIPTION
## Summary
- disable raw Docker Compose TTY output whenever an operation fans out to multiple hosts
- keep raw output for true single-target operations, including host-filtered multi-host stacks
- add CLI, executor, and operations regression coverage for multi-host stack output

## Verification
- uv run pytest tests/test_cli_lifecycle.py tests/test_executor.py tests/test_operations.py
- uv run ruff check .
- uv run ruff format --check .
- uv run cf update glances