### PR TITLE
cli: Clarify update status wording

### DIFF
--- a/src/compose_farm/operations.py
+++ b/src/compose_farm/operations.py
@@ -226,6 +226,11 @@ def build_up_cmd(
     return " ".join(parts)
 
 
+def _up_action_label(*, pull: bool = False, build: bool = False) -> str:
+    """Return the user-facing action label for an up operation."""
+    return "Updating" if pull or build else "Starting"
+
+
 async def _up_multi_host_stack(
     cfg: Config,
     stack: str,
@@ -260,7 +265,7 @@ async def _up_multi_host_stack(
 
     # Start on all hosts
     hosts_str = ", ".join(f"[magenta]{h}[/]" for h in host_names)
-    console.print(f"{prefix} Starting on {hosts_str}...")
+    console.print(f"{prefix} {_up_action_label(pull=pull, build=build)} on {hosts_str}...")
 
     succeeded_hosts: list[str] = []
     use_raw = raw and len(host_names) == 1
@@ -360,7 +365,9 @@ async def _up_single_stack(
             )
 
     # Start on target host
-    console.print(f"{prefix} Starting on [magenta]{target_host}[/]...")
+    console.print(
+        f"{prefix} {_up_action_label(pull=pull, build=build)} on [magenta]{target_host}[/]..."
+    )
     up_result = await _run_compose_step(cfg, stack, build_up_cmd(pull=pull, build=build), raw=raw)
 
     # Update state on success, or rollback on failure

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -15,6 +15,7 @@ from compose_farm.operations import (
     PreflightResult,
     _migrate_stack,
     _report_preflight_failures,
+    _up_action_label,
     build_discovery_results,
     build_up_cmd,
     check_stack_requirements,
@@ -128,6 +129,19 @@ class TestBuildUpCmd:
         assert (
             build_up_cmd(pull=True, build=True, service="web") == "up -d --pull always --build web"
         )
+
+
+class TestUpActionLabel:
+    """Tests for user-facing up action labels."""
+
+    def test_plain_up_starts(self) -> None:
+        """A plain up operation starts missing or stopped containers."""
+        assert _up_action_label() == "Starting"
+
+    @pytest.mark.parametrize(("pull", "build"), [(True, False), (False, True), (True, True)])
+    def test_pull_or_build_updates(self, pull: bool, build: bool) -> None:
+        """Update-style operations should not imply containers were restarted."""
+        assert _up_action_label(pull=pull, build=build) == "Updating"
 
 
 class TestPreflightRequirements:


### PR DESCRIPTION
## Summary
- show `Updating on ...` for up operations that include pull/build flags
- keep `Starting on ...` for plain `cf up`
- add focused tests for the action label

## Verification
- uv run pytest tests/test_operations.py
- uv run ruff check .
- uv run ruff format --check .
- uv run cf update glances