### PR TITLE
fix: warn on traefik regeneration os errors

### DIFF
--- a/src/compose_farm/cli/common.py
+++ b/src/compose_farm/cli/common.py
@@ -286,7 +286,7 @@ def maybe_regenerate_traefik(
 
         for warning in warnings:
             print_warning(warning)
-    except (FileNotFoundError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         print_warning(f"Failed to update traefik config: {exc}")
 
 

--- a/src/compose_farm/cli/common.py
+++ b/src/compose_farm/cli/common.py
@@ -272,7 +272,11 @@ def maybe_regenerate_traefik(
     try:
         dynamic, warnings = generate_traefik_config(cfg, list(cfg.stacks.keys()))
         new_content = render_traefik_config(dynamic)
+    except (FileNotFoundError, ValueError) as exc:
+        print_warning(f"Failed to update traefik config: {exc}")
+        return
 
+    try:
         # Check if content changed
         old_content = ""
         if cfg.traefik_file.exists():
@@ -284,10 +288,12 @@ def maybe_regenerate_traefik(
             console.print()  # Ensure we're on a new line after streaming output
             print_success(f"Traefik config updated: {cfg.traefik_file}")
 
-        for warning in warnings:
-            print_warning(warning)
-    except (OSError, ValueError) as exc:
+    except OSError as exc:
         print_warning(f"Failed to update traefik config: {exc}")
+        return
+
+    for warning in warnings:
+        print_warning(warning)
 
 
 def validate_stacks(cfg: Config, stacks: list[str], *, hint: str | None = None) -> None:

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -67,3 +67,26 @@ def test_maybe_regenerate_traefik_warns_on_permission_error(tmp_path: Path) -> N
         maybe_regenerate_traefik(cfg)
 
     mock_warning.assert_called_once_with("Failed to update traefik config: denied")
+
+
+def test_maybe_regenerate_traefik_propagates_input_permission_error(
+    tmp_path: Path,
+) -> None:
+    cfg = Config(
+        compose_dir=tmp_path / "compose",
+        hosts={"host1": Host(address="localhost")},
+        stacks={"traefik": "host1"},
+        traefik_file=tmp_path / "compose-farm.yml",
+    )
+
+    with (
+        patch(
+            "compose_farm.traefik.generate_traefik_config",
+            side_effect=PermissionError("compose denied"),
+        ),
+        patch("compose_farm.cli.common.print_warning") as mock_warning,
+        pytest.raises(PermissionError, match="compose denied"),
+    ):
+        maybe_regenerate_traefik(cfg)
+
+    mock_warning.assert_not_called()

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,9 +1,13 @@
 """Tests for shared CLI helpers."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 import typer
 
-from compose_farm.cli.common import report_results
+from compose_farm.cli.common import maybe_regenerate_traefik, report_results
+from compose_farm.config import Config, Host
 from compose_farm.executor import CommandResult
 
 
@@ -44,3 +48,22 @@ def test_report_results_uses_display_label_without_host(
 
     captured = capsys.readouterr()
     assert "multi@host1 failed with exit code 1" in captured.err
+
+
+def test_maybe_regenerate_traefik_warns_on_permission_error(tmp_path: Path) -> None:
+    cfg = Config(
+        compose_dir=tmp_path / "compose",
+        hosts={"host1": Host(address="localhost")},
+        stacks={"traefik": "host1"},
+        traefik_file=tmp_path / "readonly" / "compose-farm.yml",
+    )
+
+    with (
+        patch("compose_farm.traefik.generate_traefik_config", return_value=({}, [])),
+        patch("compose_farm.traefik.render_traefik_config", return_value="http: {}\n"),
+        patch("pathlib.Path.mkdir", side_effect=PermissionError("denied")),
+        patch("compose_farm.cli.common.print_warning") as mock_warning,
+    ):
+        maybe_regenerate_traefik(cfg)
+
+    mock_warning.assert_called_once_with("Failed to update traefik config: denied")


### PR DESCRIPTION
Summary:
- Catch OSError when regenerating the Traefik file-provider config.
- Add a regression test for PermissionError during Traefik config directory creation.

Testing:
- uv run pytest tests/test_cli_common.py::test_maybe_regenerate_traefik_warns_on_permission_error -q
- uv run pytest tests/test_cli_common.py::test_maybe_regenerate_traefik_warns_on_permission_error tests/test_cli_common.py -q
- just lint
- uv run pytest -m "not browser" -n auto