### PR TITLE
cli: Brighten web banner window colors

### DIFF
--- a/src/compose_farm/cli/web.py
+++ b/src/compose_farm/cli/web.py
@@ -19,8 +19,8 @@ def _compose_farm_banner() -> Text:
 
     banner = Text()
     structure = "bright_cyan"
-    windows = "yellow"
-    attic_window = "red"
+    windows = "bright_yellow"
+    attic_window = "bright_red"
 
     banner.append("           .-^-.\n", style=structure)
     banner.append("        .-'  ", style=structure)


### PR DESCRIPTION
## Summary
- use `bright_yellow` for the lower banner windows
- use `bright_red` for the attic banner window

## Verification
- uv run pytest tests/test_cli_web.py
- uv run ruff check src/compose_farm/cli/web.py tests/test_cli_web.py
- uv run ruff format --check src/compose_farm/cli/web.py tests/test_cli_web.py
- pre-commit hooks from commit
